### PR TITLE
Use String keys when loading maps

### DIFF
--- a/lib/money/ecto/amount_type.ex
+++ b/lib/money/ecto/amount_type.ex
@@ -65,9 +65,9 @@ if Code.ensure_loaded?(Ecto.Type) do
 
     def cast(_), do: :error
 
-    @spec load(integer() | %{amount: integer(), currency: String.t()}) :: {:ok, Money.t()}
+    @spec load(integer() | map()) :: {:ok, Money.t()}
     def load(int) when is_integer(int), do: {:ok, Money.new(int)}
-    def load(%{amount: amount, currency: currency}), do: {:ok, Money.new(amount, currency)}
+    def load(%{"amount" => amount, "currency" => currency}), do: {:ok, Money.new(amount, currency)}
 
     @spec dump(integer() | Money.t()) :: {:ok, integer()}
     def dump(int) when is_integer(int), do: {:ok, int}

--- a/test/money/ecto/amount_type_test.exs
+++ b/test/money/ecto/amount_type_test.exs
@@ -57,7 +57,7 @@ defmodule Money.Ecto.Amount.TypeTest do
   end
 
   test "load/1 map" do
-    assert Type.load(%{amount: 1_619_00, currency: "USD"}) == {:ok, Money.new(1_619_00, :USD)}
+    assert Type.load(%{"amount" => 1_619_00, "currency" => "USD"}) == {:ok, Money.new(1_619_00, :USD)}
   end
 
   test "dump/1 integer" do


### PR DESCRIPTION
I messed up in #1 thinking that the keys would be atoms. They're not, they're strings.